### PR TITLE
Update core file dependencies

### DIFF
--- a/board/xwrc_board_kasli.core
+++ b/board/xwrc_board_kasli.core
@@ -14,8 +14,8 @@ filesets:
       - ohwr:etherbone:etherbone_pkg
       - ohwr:wrpc:xwr_si549_interface
     files:
-      - kasli/wr_kasli_pkg.vhd
       - kasli/xwrc_board_kasli_regs.vhd
+      - kasli/wr_kasli_pkg.vhd
       - kasli/xwrc_board_kasli.vhd
     file_type: vhdlSource
 

--- a/platform/xwrc_platform_xilinx.core
+++ b/platform/xwrc_platform_xilinx.core
@@ -6,8 +6,9 @@ filesets:
   rtl:
     depend:
       - ohwr:wrpc:disparity_gen_pkg
+      - ohwr:general-cores:gencores_pkg
       - ohwr:general-cores:wishbone_pkg
-      - ohwr:wrpc:wr_endpoint
+      - ohwr:wrpc:wr_endpoint # provides endpoint_pkg
     files:
       - xilinx/wr_gtp_phy/family7-gtx/whiterabbit_gtxe2_channel_wrapper_gt.vhd
       - xilinx/wr_gtp_phy/family7-gtx/wr_gtx_phy_family7.vhd

--- a/platform/xwrc_platform_xilinx.core
+++ b/platform/xwrc_platform_xilinx.core
@@ -6,6 +6,8 @@ filesets:
   rtl:
     depend:
       - ohwr:wrpc:disparity_gen_pkg
+      - ohwr:general-cores:wishbone_pkg
+      - ohwr:wrpc:wr_endpoint
     files:
       - xilinx/wr_gtp_phy/family7-gtx/whiterabbit_gtxe2_channel_wrapper_gt.vhd
       - xilinx/wr_gtp_phy/family7-gtx/wr_gtx_phy_family7.vhd


### PR DESCRIPTION
In attempting to get an Xcelium simulation running there were a few core files which didnt have the correct dependencies. This fixes those.