### PR TITLE
fixup: correct `g_fabric_iface` parameter case

### DIFF
--- a/board/kasli/wrc_board_kasli.vhd
+++ b/board/kasli/wrc_board_kasli.vhd
@@ -59,10 +59,10 @@ entity wrc_board_kasli is
   generic (
     -- set to 1 to speed up some initialization processes during simulation
     g_simulation : integer := 0;
-    -- "plainfbrc" = expose WRC fabric interface
-    -- "streamers" = attach WRC streamers to fabric interface
-    -- "etherbone" = attach Etherbone slave to fabric interface
-    g_fabric_iface : string := "plainfbrc";
+    -- "PLAINFBRC" = expose WRC fabric interface
+    -- "STREAMERS" = attach WRC streamers to fabric interface
+    -- "ETHERBONE" = attach Etherbone slave to fabric interface
+    g_fabric_iface : string := "PLAINFBRC";
     -- parameters configuration when g_fabric_iface = "streamers" (otherwise ignored)
     -- g_streamers_op_mode        : t_streamers_op_mode  := TX_AND_RX;
     -- g_tx_streamer_params       : t_tx_streamer_params := c_tx_streamer_params_defaut;


### PR DESCRIPTION
This string parameter is converted to a type with the `f_str2iface_type` function defined as:

```
function f_str2iface_type (
    constant iface_str : string(1 to 9))
    return t_board_fabric_iface is
    variable result : t_board_fabric_iface;
  begin
    case iface_str is
      when "PLAINFBRC" => result := PLAIN;
      when "STREAMERS" => result := STREAMERS;
      when "ETHERBONE" => result := ETHERBONE;
      when others      => result := always_last_invalid;
    end case;
    return result;
  end function f_str2iface_type;
```

In its current implementation the parameter was "plainfbrc" but the match is case sensitive, hence causing simulation errors. 