### PR TITLE
fixup: corrects `f_(de)vectorise_diag` indexing

### DIFF
--- a/board/common/wr_board_pkg.vhd
+++ b/board/common/wr_board_pkg.vhd
@@ -338,7 +338,7 @@ package body wr_board_pkg is
       "g_diag_ro/w_vector_width must have value that is a mutiple of 32"
       severity FAILURE;
     for i in 0 to diag_vector_size/32-1 loop
-      result(i*32-31 downto i*32) := diag_in(i);
+      result(i*32+31 downto i*32) := diag_in(i);
     end loop;
     return result;
   end function f_vectorize_diag;
@@ -353,7 +353,7 @@ package body wr_board_pkg is
       "g_diag_ro/w_vector_width must have value that is a mutiple of 32"
       severity FAILURE;
     for i in 0 to diag_vector_size/32-1 loop
-      result(i) := diag_in(i*32-31 downto i*32);
+      result(i) := diag_in(i*32+31 downto i*32);
     end loop;
     return result;
   end function f_de_vectorize_diag;


### PR DESCRIPTION
Previously these functions indexed their flat `std_logic_vector`s as:
```
sig(i*32-31 downto i*32)
```
This yields (for `i = 0,1,2,...`):
```
i = 0 : sig(-31 downto 0) = ... 
i = 1 : sig(1 downto 32) = ...
i = 2 : sig(33 downto 64) = ...  
```
which is evidently wrong. This has been confirmed with CERN [here](https://forums.ohwr.org/t/f-de-vectorize-diag-function-implementation-issue/849322)