### PR TITLE
fix/NQ-1883: Xcelium support

### DIFF
--- a/modules/wrc_core/wrc_periph.vhd
+++ b/modules/wrc_core/wrc_periph.vhd
@@ -455,8 +455,8 @@ begin
       g_interface_mode      => PIPELINED,
       g_address_granularity => BYTE,
       g_num_ports           => 2,
-      g_ow_btp_normal       => "5.0",
-      g_ow_btp_overdrive    => "1.0"
+      g_ow_btp_normal       => 50,
+      g_ow_btp_overdrive    => 10
       )
     port map(
       clk_sys_i => clk_sys_i,


### PR DESCRIPTION
The general-cores PR https://github.com/NuQuantum/general-cores/pull/5 makes a number of modifications necessary to support simulating the WR core in xcelium.  Some of those changes propagate to this repo. This PR implements such changes.