### PR TITLE
feat(NQ-2591, rowr): Ammend aux clock config for ARTIQ integration

### DIFF
--- a/board/kasli/wr_kasli_pkg.vhd
+++ b/board/kasli/wr_kasli_pkg.vhd
@@ -58,7 +58,7 @@ package wr_kasli_pkg is
   constant c_num_wb_crossbar_slaves           : integer := 5;
   constant c_wb_crossbar_address_vector_width : integer := c_wishbone_address_width * c_num_wb_crossbar_slaves;
 
-  constant c_num_aux_clocks : integer := 3;
+  constant c_num_aux_clocks : integer := 2;
 
   -- Address Map for the componenets connected to the WB_Crossbar outside the WRPC core - secondary crossbar.
   -- Addresses in the range 0x00020000 to 0x0002_0800 belong to HDL modules connected to the primary crossar.

--- a/board/kasli/wrc_board_kasli.vhd
+++ b/board/kasli/wrc_board_kasli.vhd
@@ -337,13 +337,11 @@ architecture std_wrapper of wrc_board_kasli is
   -- sys PLL aux clock config
   constant c_auxpll_cfg_rtio_125m : t_auxpll_cfg       := (TRUE, TRUE, 8);
   constant c_auxpll_cfg_rtio_500m : t_auxpll_cfg       := (TRUE, TRUE, 2);
-  constant c_auxpll_cfg_rtio_200m : t_auxpll_cfg       := (TRUE, TRUE, 5);
   constant c_auxpll_cfg           : t_auxpll_cfg_array :=
   (
-    c_auxpll_cfg_rtio_200m,
-    c_auxpll_cfg_rtio_500m,
-    c_auxpll_cfg_rtio_125m,
-    c_AUXPLL_CFG_DEFAULT
+    0 => c_auxpll_cfg_rtio_125m,
+    1 => c_auxpll_cfg_rtio_500m,
+    others => c_AUXPLL_CFG_DEFAULT
   );
 
   -- vsg_on
@@ -443,6 +441,7 @@ begin  -- architecture struct
   cmp_xwrc_board_kasli : component xwrc_board_kasli
     generic map (
       g_simulation              => g_simulation,
+      g_dbg_bits                => g_dbg_bits,
       g_aux_clks                => c_num_aux_clocks,
       g_fabric_iface            => f_str2iface_type(g_fabric_iface),
       g_streamers_op_mode       => TX_AND_RX,
@@ -463,8 +462,10 @@ begin  -- architecture struct
       clk_125m_gtp_n_i       => clk_125m_gtp_n_i,
       clk_125m_bootstrap_p_i => clk_125m_bootstrap_p_i,
       clk_125m_bootstrap_n_i => clk_125m_bootstrap_n_i,
-      --
+      -- Generated sys clock and reset
+      clk_sys_62m5_o         => clk_sys_62m5_o,
       rst_sys_62m5_n_o       => rst_sys_62m5_n_o,
+      -- Generated bootstrap reset
       rst_bootstrap_62m5_n_o => rst_bootstrap_62m5_n_o,
       -- Auxillary clocks / reset
       clk_aux_o   => clk_aux_o,
@@ -547,7 +548,6 @@ begin  -- architecture struct
       pps_led_o => pps_led_o,
       --
       link_ok_o => link_ok_o,
-
       -- debug
       dbg_bus_o => dbg_bus_o
     );

--- a/board/kasli/xwrc_board_kasli.vhd
+++ b/board/kasli/xwrc_board_kasli.vhd
@@ -284,9 +284,9 @@ architecture struct of xwrc_board_kasli is
   signal pll_sys_locked : std_logic;
 
   -- Reset logic
-  signal sys_rstlogic_clk_in  : std_logic_vector(3 downto 0);
+  signal sys_rstlogic_clk_in  : std_logic_vector((1 + c_num_aux_clocks) - 1 downto 0);
   signal sys_rstlogic_arst_n  : std_logic;
-  signal sys_rstlogic_rst_out : std_logic_vector(3 downto 0);
+  signal sys_rstlogic_rst_out : std_logic_vector((1 + c_num_aux_clocks) - 1 downto 0);
 
   signal bootstrap_rstlogic_clk_in  : std_logic_vector(1 downto 0);
   signal bootstrap_rstlogic_arst_n  : std_logic;
@@ -297,15 +297,10 @@ architecture struct of xwrc_board_kasli is
   signal rst_bootstrap_125m_n : std_logic;
 
   -- Async reset generation and clock selection
-  type t_pll_reset_state is (ST_IDLE, ST_RESET, ST_DONE);
   signal pll_areset_n       : std_logic;
   signal pll_clk_sys_sel    : std_logic;
-  signal clk_sel_change     : std_logic;
-  signal pll_reset_state_q  : t_pll_reset_state := ST_IDLE;
-  signal pll_reset_count_q  : unsigned(16 downto 0) := (others => '0');
   signal rst_wrpc_core      : std_logic;
   signal sys_clk_select     : std_logic;
-  signal clk_sel_changed    : std_logic;
 
   -- Registers
   signal reg2hw : t_wrpc_kasli_regs_master_out;
@@ -365,6 +360,9 @@ architecture struct of xwrc_board_kasli is
 
   signal eeprom_scl_t_n :  std_logic;
   signal eeprom_sda_t_n :  std_logic;
+
+  signal tm_link_up : std_logic;
+  signal tm_time_valid : std_logic;
 
 begin  -- architecture struct
 
@@ -604,8 +602,10 @@ begin  -- architecture struct
   bootstrap_rstlogic_arst_n <= pll_sys_locked or sys_clk_select;
 
   -- concatenation of all clocks required to have synced resets
-  sys_rstlogic_clk_in(0)          <= clk_pll_62m5;
-  sys_rstlogic_clk_in(3 downto 1) <= clk_pll_aux(c_num_aux_clocks - 1 downto 0);
+  sys_rstlogic_clk_in(0)                         <= clk_pll_62m5;
+  sys_rstlogic_clk_in(c_num_aux_clocks downto 1) <= (
+    clk_pll_aux(c_num_aux_clocks - 1 downto 0)
+  );
 
   -- TODO: free_clock_i -> locked_i false path
   u_sys_rstlogic_reset : component gc_reset
@@ -645,7 +645,7 @@ begin  -- architecture struct
 
   -- Export the resets for use in higher level startup
   rst_sys_62m5_n_o       <= rst_sys_62m5_n;
-  rst_aux_n_o            <= sys_rstlogic_rst_out(3 downto 1);
+  rst_aux_n_o            <= sys_rstlogic_rst_out(c_num_aux_clocks downto 1);
   rst_bootstrap_62m5_n_o <= rst_bootstrap_62m5_n;
 
   -----------------------------------------------------------------------------
@@ -705,7 +705,7 @@ begin  -- architecture struct
       g_interface_mode            => PIPELINED,
       g_address_granularity       => BYTE,
       g_aux_sdb                   => c_wrc_periph3_sdb,
-      g_softpll_enable_debugger   => FALSE,
+      g_softpll_enable_debugger   => TRUE,
       g_vuart_fifo_size           => 1024,
       g_pcs_16bit                 => TRUE,
       g_diag_id                   => g_diag_id,
@@ -773,17 +773,22 @@ begin  -- architecture struct
       tm_dac_wr_o          => tm_dac_wr_o,
       tm_clk_aux_lock_en_i => tm_clk_aux_lock_en_i,
       tm_clk_aux_locked_o  => tm_clk_aux_locked_o,
+      --
       timestamps_o         => timestamps_o,
       timestamps_ack_i     => timestamps_ack_i,
+      --
       abscal_txts_o        => abscal_txts_o,
       abscal_rxts_o        => abscal_rxts_o,
+      --
       fc_tx_pause_req_i    => fc_tx_pause_req_i,
       fc_tx_pause_delay_i  => fc_tx_pause_delay_i,
       fc_tx_pause_ready_o  => fc_tx_pause_ready_o,
-      tm_link_up_o         => tm_link_up_o,
-      tm_time_valid_o      => tm_time_valid_o,
+      --
+      tm_link_up_o         => tm_link_up,
+      tm_time_valid_o      => tm_time_valid,
       tm_tai_o             => tm_tai_o,
       tm_cycles_o          => tm_cycles_o,
+      --
       led_act_o            => led_act_o,
       led_link_o           => led_link_o,
       pps_p_o              => pps_p_o,
@@ -805,6 +810,9 @@ begin  -- architecture struct
   eeprom_sda_o <= '0';
   eeprom_scl_o <= '0';
 
+  tm_link_up_o    <= tm_link_up;
+  tm_time_valid_o <= tm_time_valid;
+
   -----------------------------------------------------------------------------
   -- Debugging
   -----------------------------------------------------------------------------
@@ -815,5 +823,7 @@ begin  -- architecture struct
   dbg_bus_o(3) <= pll_sys_locked;
   dbg_bus_o(4) <= pll_areset_n;
   dbg_bus_o(5) <= pll_clk_sys_sel;
+  dbg_bus_o(6) <= tm_link_up;
+  dbg_bus_o(7) <= tm_time_valid;
 
 end architecture struct;

--- a/board/kasli/xwrc_board_kasli.vhd
+++ b/board/kasli/xwrc_board_kasli.vhd
@@ -277,7 +277,7 @@ architecture struct of xwrc_board_kasli is
 
   -- PLLs, clocks
   signal clk_pll_62m5   : std_logic;
-  signal clk_pll_125m   : std_logic;
+  signal clk_ref_62m5   : std_logic;
   signal clk_pll_dmtd   : std_logic;
   signal clk_pll_aux    : std_logic_vector(3 downto 0);
   signal pll_locked     : std_logic;
@@ -574,7 +574,7 @@ begin  -- architecture struct
       sfp_tx_disable_o       => sfp_tx_disable,
       -- output clocks
       clk_62m5_sys_o         => clk_pll_62m5,
-      clk_125m_ref_o         => clk_pll_125m,
+      clk_62m5_ref_o         => clk_ref_62m5,
       clk_62m5_dmtd_o        => clk_pll_dmtd,
       clk_pll_aux_o          => clk_pll_aux,
       -- lock status
@@ -721,7 +721,7 @@ begin  -- architecture struct
     port map (
       clk_sys_i            => clk_pll_62m5,
       clk_dmtd_i           => clk_pll_dmtd,
-      clk_ref_i            => clk_pll_125m,
+      clk_ref_i            => clk_ref_62m5,
       rst_n_i              => rst_sys_62m5_n,
       -- Helper PLL updates
       dac_hpll_load_p1_o => dac_pll_load_p1(1),

--- a/platform/xilinx/wr_xilinx_pkg.vhd
+++ b/platform/xilinx/wr_xilinx_pkg.vhd
@@ -403,8 +403,7 @@ package wr_xilinx_pkg is
       clk_pll_aux_o          : out std_logic_vector(3 downto 0);
       pll_aux_locked_o       : out std_logic;
       clk_62m5_sys_o         : out std_logic;
-      clk_125m_ref_o         : out std_logic;
-      clk_20m_o              : out std_logic;
+      clk_62m5_ref_o         : out std_logic;
       clk_ref_locked_o       : out std_logic;
       clk_62m5_dmtd_o        : out std_logic;
       clk_250m_dmtd_over_o   : out std_logic;

--- a/platform/xilinx/xwrc_platform_kintex7.vhd
+++ b/platform/xilinx/xwrc_platform_kintex7.vhd
@@ -135,8 +135,7 @@ entity xwrc_platform_kintex7 is
     ---------------------------------------------------------------------------
     -- PLL outputs
     clk_62m5_sys_o         : out std_logic;
-    clk_125m_ref_o         : out std_logic;
-    clk_20m_o              : out std_logic;
+    clk_62m5_ref_o         : out std_logic;
     clk_ref_locked_o       : out std_logic;
     clk_62m5_dmtd_o        : out std_logic;
     clk_250m_dmtd_over_o   : out std_logic;
@@ -603,7 +602,7 @@ begin  -- architecture rtl
 
       tx_locked_o   => clk_ref_locked);
 
-  clk_125m_ref_o       <= clk_ref;
+  clk_62m5_ref_o       <= clk_ref;
   clk_ref_locked_o     <= clk_ref_locked;
   phy16_o.ref_clk      <= clk_ref;
   phy16_o.sfp_tx_fault <= sfp_tx_fault_i;


### PR DESCRIPTION
# Overview 
This PR ammends to auxiliary clock configuration of the Kasli WRPC to suit the RoWR design of NQ-2591.

## Review Notes
- the `clk_125m_ref_o` of `xwrc_platform_kintex7.vhd` has been renamed to `clk_62m5_ref_o` ... since its actually a 62.5MHz signal. The existing naming was carried over from the `xwrc_platform_xilinx.vhd` where I believe under certain configurations this signal could be 125MHz, but in ours it was not.
- `clk_20m_o` signal is removed as its unused
- Reduces the number of aux clocks from 3 to 2 (125MHz sys, 500MHz serdes)
- Proper parameterisation of signals based on `c_num_aux_clocks`