### PR TITLE
refactor: Constant width debug bus

### DIFF
--- a/board/kasli/wr_kasli_pkg.vhd
+++ b/board/kasli/wr_kasli_pkg.vhd
@@ -152,8 +152,6 @@ package wr_kasli_pkg is
     generic (
       -- set to 1 to speed up some initialization processes during simulation
       g_simulation : integer := 0;
-      -- Define how many debug signals are exported to the top level
-      g_dbg_bits : integer := 6;
       -- "plainfbrc" = expose WRC fabric interface
       -- "streamers" = attach WRC streamers to fabric interface
       -- "etherbone" = attach Etherbone slave to fabric interface
@@ -391,7 +389,7 @@ package wr_kasli_pkg is
       ---------------------------------------------------------------------------
       -- Debug interface for clock_select, reset and clock
       ---------------------------------------------------------------------------
-      dbg_bus_o : out   std_logic_vector(g_dbg_bits-1 downto 0)
+      dbg_bus_o : out   std_logic_vector(7 downto 0)
     );
   end component wrc_board_kasli;
 
@@ -399,8 +397,6 @@ package wr_kasli_pkg is
     generic (
       -- set to 1 to speed up some initialization processes during simulation
       g_simulation : integer := 0;
-      -- Define how many debug signals are exported to the top level
-      g_dbg_bits : integer := 6;
       -- Select whether to include external ref clock input
       g_aux_clks : integer := 4;
       -- plain     = expose WRC fabric interface
@@ -584,7 +580,7 @@ package wr_kasli_pkg is
       ---------------------------------------------------------------------------
       -- Debug interface for clock_select, reset and clock
       ---------------------------------------------------------------------------
-      dbg_bus_o : out   std_logic_vector(g_dbg_bits-1 downto 0)
+      dbg_bus_o : out   std_logic_vector(7 downto 0)
     );
   end component xwrc_board_kasli;
 

--- a/board/kasli/wrc_board_kasli.vhd
+++ b/board/kasli/wrc_board_kasli.vhd
@@ -59,8 +59,6 @@ entity wrc_board_kasli is
   generic (
     -- set to 1 to speed up some initialization processes during simulation
     g_simulation : integer := 0;
-    -- Define how many debug signals are exported to the top level
-    g_dbg_bits : integer := 6;
     -- "PLAINFBRC" = expose WRC fabric interface
     -- "STREAMERS" = attach WRC streamers to fabric interface
     -- "ETHERBONE" = attach Etherbone slave to fabric interface
@@ -298,7 +296,7 @@ entity wrc_board_kasli is
     ---------------------------------------------------------------------------
     -- Debug interface for clock_select, reset and clock
     ---------------------------------------------------------------------------
-    dbg_bus_o : out   std_logic_vector(g_dbg_bits-1 downto 0)
+    dbg_bus_o : out   std_logic_vector(7 downto 0)
   );
 end entity wrc_board_kasli;
 
@@ -441,7 +439,6 @@ begin  -- architecture struct
   cmp_xwrc_board_kasli : component xwrc_board_kasli
     generic map (
       g_simulation              => g_simulation,
-      g_dbg_bits                => g_dbg_bits,
       g_aux_clks                => c_num_aux_clocks,
       g_fabric_iface            => f_str2iface_type(g_fabric_iface),
       g_streamers_op_mode       => TX_AND_RX,

--- a/board/kasli/xwrc_board_kasli.vhd
+++ b/board/kasli/xwrc_board_kasli.vhd
@@ -62,8 +62,6 @@ entity xwrc_board_kasli is
   generic (
     -- set to 1 to speed up some initialization processes during simulation
     g_simulation : integer := 0;
-    -- Define how many debug signals are exported to the top level
-    g_dbg_bits : integer := 6;
     -- Select whether to include external ref clock input
     g_aux_clks : integer := 4;
     -- plain     = expose WRC fabric interface
@@ -247,7 +245,7 @@ entity xwrc_board_kasli is
     ---------------------------------------------------------------------------
     -- Debug interface for clock_select, reset and clock
     ---------------------------------------------------------------------------
-    dbg_bus_o : out   std_logic_vector(g_dbg_bits-1 downto 0)
+    dbg_bus_o : out   std_logic_vector(7 downto 0)
   );
 end entity xwrc_board_kasli;
 
@@ -363,6 +361,8 @@ architecture struct of xwrc_board_kasli is
 
   signal tm_link_up : std_logic;
   signal tm_time_valid : std_logic;
+
+  signal pps_p : std_logic;
 
 begin  -- architecture struct
 
@@ -791,7 +791,7 @@ begin  -- architecture struct
       --
       led_act_o            => led_act_o,
       led_link_o           => led_link_o,
-      pps_p_o              => pps_p_o,
+      pps_p_o              => pps_p,
       pps_led_o            => pps_led_o,
       link_ok_o            => link_ok_o
     );
@@ -812,6 +812,8 @@ begin  -- architecture struct
 
   tm_link_up_o    <= tm_link_up;
   tm_time_valid_o <= tm_time_valid;
+
+  pps_p_o <= pps_p;
 
   -----------------------------------------------------------------------------
   -- Debugging

--- a/board/kasli/xwrc_board_kasli.vhd
+++ b/board/kasli/xwrc_board_kasli.vhd
@@ -826,6 +826,6 @@ begin  -- architecture struct
   dbg_bus_o(4) <= pll_areset_n;
   dbg_bus_o(5) <= pll_clk_sys_sel;
   dbg_bus_o(6) <= tm_link_up;
-  dbg_bus_o(7) <= tm_time_valid;
+  dbg_bus_o(7) <= pps_p;
 
 end architecture struct;


### PR DESCRIPTION
Till now the `xwrc_board_kasli` debug bus' width has been parameterised by a `g_dbg_bits` parameter. Despite this, within `xwrc_board_kasli` we assign directly to the bus as if it always has 8 bits. Therefore if a value of `g_dbg_bits` other than 8 is passed, the module would fail to synthesize. 

In this PR I propose that the debug bus be fixed at 8-bits in width, such that the responsibility to decide how many bits to export is on the modules further up the hierarchy which instantiate `xwrc_board_kasli`. We also export the `pps_p` signal to the debug bus such that this doesnt need to be performed further up the hierarchy, as in https://github.com/NuQuantum/nq-control/blob/a6354ae11c89244dc2f4c1feadab0644ced21f69/hw/boards/kasli_soc/top_kasli_soc_wrpc/rtl/kasli_soc_wrpc.sv#L740.